### PR TITLE
Fix error NullPointerException when read item contains null value

### DIFF
--- a/src/main/java/com/citusdata/migration/DynamoDBTableReplicator.java
+++ b/src/main/java/com/citusdata/migration/DynamoDBTableReplicator.java
@@ -560,7 +560,11 @@ public class DynamoDBTableReplicator {
 				row.setValue(columnName, columnValue);
 			}
 
-			item.with(keyName, columnValue.datum);
+			if (columnValue != null) {
+				item.with(keyName, columnValue.datum);
+			} else {
+				item.with(keyName, null);
+			}
 		}
 
 		row.setValue("data", item.toJSON());


### PR DESCRIPTION
Error happen when podyn try to replicate data from dynamoDB. Root cause is some items contain null value such as:
{
"field1": null,
"field2": "abc"
}

**Detail logs:**

019-02-18 09:36:15 ERROR DynamoDBReplicator:266 - null
java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[?:1.8.0_181]
	at java.util.concurrent.FutureTask.get(FutureTask.java:192) ~[?:1.8.0_181]
	at com.citusdata.migration.DynamoDBReplicator.main(DynamoDBReplicator.java:237) [podyn.jar:?]
Caused by: java.lang.NullPointerException
	at com.citusdata.migration.DynamoDBTableReplicator.rowWithJsonbFromDynamoRecord(DynamoDBTableReplicator.java:563) ~[podyn.jar:?]
	at com.citusdata.migration.DynamoDBTableReplicator.rowFromDynamoRecord(DynamoDBTableReplicator.java:537) ~[podyn.jar:?]
	at com.citusdata.migration.DynamoDBTableReplicator.replicateData(DynamoDBTableReplicator.java:256) ~[podyn.jar:?]
	at com.citusdata.migration.DynamoDBTableReplicator$1.call(DynamoDBTableReplicator.java:233) ~[podyn.jar:?]
	at com.citusdata.migration.DynamoDBTableReplicator$1.call(DynamoDBTableReplicator.java:230) ~[podyn.jar:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_181]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_181]
2019-02-18 09:36:15 INFO  DynamoDBReplicator:183 - Closing database connections